### PR TITLE
Should not alter html outside of head

### DIFF
--- a/index.js
+++ b/index.js
@@ -125,7 +125,6 @@
                 files.push(saveTo);
             });
             convert(files.concat([
-                '-alpha off',
                 '-background none',
                 options.trueColor ? '' : '-bordercolor white -border 0 -colors 64',
                 path.join(options.dest, 'favicon.ico')


### PR DESCRIPTION
By default cheerio replaces ", ' and other entities with &quot;, &apos; etc. which can be a problem with angularjs, django etc.
