### PR TITLE
Synchronously create the dest directory

### DIFF
--- a/index.js
+++ b/index.js
@@ -235,7 +235,7 @@
                 return console.log('A source image is required');
             }
             if (!fs.existsSync(options.dest) || !fs.lstatSync(options.dest).isDirectory()) {
-                mkdirp(options.dest);
+                mkdirp.sync(options.dest);
             }
             makeIcons();
             writeTags(function (data) {


### PR DESCRIPTION
Using the package within a gulp workflow, the `convert` function was called before the `options.dest` exists. So the favicons weren't generated the first time I launched the workflow but only when the dest folder was on the file system.
