### PR TITLE
Add option for 'short_name' in manifest.json

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -31,6 +31,7 @@ var favicons = require('favicons'),
     configuration = {          
         path: "/",                                // Path for overriding default icons path. `string`
         appName: null,                            // Your application's name. `string`
+        appShortName: null,                       // Your application's short_name. `string`. Optional. If not set, appName will be used
         appDescription: null,                     // Your application's description. `string`
         developerName: null,                      // Your (or your developer's) name. `string`
         developerURL: null,                       // Your (or your developer's) URL. `string`
@@ -97,6 +98,7 @@ var favicons = require("favicons").stream,
 gulp.task("default", function () {
     return gulp.src("logo.png").pipe(favicons({
         appName: "My App",
+        appShortName: "App",
         appDescription: "This is my application",
         developerName: "Hayden Bleasel",
         developerURL: "http://haydenbleasel.com/",

--- a/src/config/defaults.json
+++ b/src/config/defaults.json
@@ -1,6 +1,7 @@
 {
   "path": "/",
   "appName": null,
+  "appShortName": null,
   "appDescription": null,
   "developerName": null,
   "developerURL": null,

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -129,7 +129,7 @@ module.exports = function(options) {
           log("Files:create", `Creating file: ${name}`);
           if (name === "manifest.json") {
             properties.name = options.appName;
-            properties.short_name = options.appName;
+            properties.short_name = options.appShortName || options.appName;
             properties.description = options.appDescription;
             properties.dir = options.dir;
             properties.lang = options.lang;

--- a/test/meta.test.js
+++ b/test/meta.test.js
@@ -8,6 +8,7 @@ test("should allow specifying metadata", async t => {
 
   const result = await favicons(logo_png, {
     appName: "PWA",
+    appShortName: "PWA",
     appDescription: "Progressive Web App",
     developerName: "John Doe",
     developerURL: "https://john.doe.com",


### PR DESCRIPTION
This will help prevent the error when `name` field is longer than 12 characters, causing `short_name` to be too long.

```
The short_name will be truncated on the homescreen
Failure: Manifest's `short_name` is too long (>12 characters) to be displayed on a homescreen without truncation.
```

<img width="714" alt="screen shot 2018-10-19 at 9 04 31 pm" src="https://user-images.githubusercontent.com/827756/47249548-b9ea2680-d3e2-11e8-9f29-c7ce9df6ad36.png">
