### PR TITLE
Updated README.md according to gulp-util deprecation

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -93,7 +93,7 @@ To use Favicons with Gulp, do as follows:
 
 ```js
 var favicons = require("favicons").stream,
-    gutil = require("gulp-util");
+    log = require("fancy-log");
 
 gulp.task("default", function () {
     return gulp.src("logo.png").pipe(favicons({
@@ -115,7 +115,7 @@ gulp.task("default", function () {
         pipeHTML: true,
         replace: true
     }))
-    .on("error", gutil.log)
+    .on("error", log)
     .pipe(gulp.dest("./"));
 });
 ```


### PR DESCRIPTION
Just me being very nitpicking about the gulp usage of this module in the README file. 😄 

In short: `gulp-util` has been deprecated and separated into smaller modules.
The example in the README uses only the `gulp-util.log` submodule which is now under the `fancy-log` module, so I think it should be better to use it instead of relying on the old `gulp-util` (which I guess won't be maintained anymore officially).

For more info: https://medium.com/gulpjs/gulp-util-ca3b1f9f9ac5

