### PR TITLE
Add support for `related_applications`

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -44,6 +44,8 @@ var favicons = require('favicons'),
         orientation: "any",                       // Default orientation: "any", "natural", "portrait" or "landscape". `string`
         scope: "/",                               // set of URLs that the browser considers within your app
         start_url: "/?homescreen=1",              // Start URL when launching the application from a device. `string`
+        preferRelatedApplications: false,         // Should the browser prompt the user to install the native companion app. `boolean`
+        relatedApplications: [],                  // Information about the native companion apps. This will only be used if `preferRelatedApplications` is `true`. `Array<{ id: string, url: string, platform: string }>`
         version: "1.0",                           // Your application's version string. `string`
         logging: false,                           // Print logs to console? `boolean`
         pixel_art: false,                         // Keeps pixels "sharp" when scaling up, for pixel art.  Only supported in offline mode.

--- a/src/config/defaults.json
+++ b/src/config/defaults.json
@@ -19,6 +19,8 @@
   "pixel_art": false,
   "loadManifestWithCredentials": false,
   "manifestRelativePaths": false,
+  "preferRelatedApplications": false,
+  "relatedApplications": [],
   "icons": {
     "android": true,
     "appleIcon": true,

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -179,6 +179,10 @@ module.exports = function(options) {
             properties.start_url = options.start_url;
             properties.background_color = options.background;
             properties.theme_color = options.theme_color;
+            properties.prefer_related_applications =
+              options.preferRelatedApplications;
+            properties.related_applications = options.relatedApplications;
+
             properties.icons.map(
               icon =>
                 (icon.src = relative(icon.src, options.manifestRelativePaths))

--- a/test/createExamples.js
+++ b/test/createExamples.js
@@ -24,6 +24,8 @@ const favicons = require('../dist/index.js'),
         orientation: "any",                       // Default orientation: "any", "natural", "portrait" or "landscape". `string`
         scope: "/",                               // set of URLs that the browser considers within your app
         start_url: "/?homescreen=1",              // Start URL when launching the application from a device. `string`
+        preferRelatedApplications: false,         // Should the browser prompt the user to install the native companion app. `boolean`
+        relatedApplications: [],                  // Information about the native companion apps. This will only be used if `preferRelatedApplications` is `true`. `Array<{ id: string, url: string, platform: string }>`
         version: "1.0",                           // Your application's version string. `string`
         logging: false,                           // Print logs to console? `boolean`
         pixel_art: false,                         // Keeps pixels "sharp" when scaling up, for pixel art.  Only supported in offline mode.


### PR DESCRIPTION
## Why

- I'd like to link my native apps to my PWAs
- Make the output manifest more spec compliant with: [related_applications](https://developer.mozilla.org/en-US/docs/Web/Manifest/related_applications)

## How

- Add the fields `relatedApplications` and `preferRelatedApplications` in the most straightforward way (as I'm not a common contributor to this repo).
- Document what the fields are used for.
- Add non-breaking defaults that don't enable any new features.
