### PR TITLE
feat: add apple platform for single apple-touch-icon

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -28,7 +28,7 @@ Please note: Favicons is tested on Node 10.13 and above.
 ```js
 var favicons = require('favicons'),
     source = 'test/logo.png',                     // Source image(s). `string`, `buffer` or array of `string`
-    configuration = {          
+    configuration = {
         path: "/",                                // Path for overriding default icons path. `string`
         appName: null,                            // Your application's name. `string`
         appShortName: null,                       // Your application's short_name. `string`. Optional. If not set, appName will be used
@@ -60,7 +60,8 @@ var favicons = require('favicons'),
             //   * overlayShadow - apply drop shadow after mask has been applied .`boolean`
             //
             android: true,              // Create Android homescreen icon. `boolean` or `{ offset, background, mask, overlayGlow, overlayShadow }`
-            appleIcon: true,            // Create Apple touch icons. `boolean` or `{ offset, background, mask, overlayGlow, overlayShadow }`
+            apple: false,               // Create a single Apple touch icon (180x180). `boolean` or `{ offset, background, mask, overlayGlow, overlayShadow }`
+            appleIcon: true,            // Create all Apple touch icons. `boolean` or `{ offset, background, mask, overlayGlow, overlayShadow }`
             appleStartup: true,         // Create Apple startup images. `boolean` or `{ offset, background, mask, overlayGlow, overlayShadow }`
             coast: true,                // Create Opera Coast icon. `boolean` or `{ offset, background, mask, overlayGlow, overlayShadow }`
             favicons: true,             // Create regular favicons. `boolean` or `{ offset, background, mask, overlayGlow, overlayShadow }`
@@ -130,6 +131,26 @@ For the full list of files, check `config/files.json`. For the full HTML code, c
 > Why are you missing certain favicons?
 
 Because pure Javascript modules aren't available at the moment. For example, the [El Capitan SVG favicon](https://github.com/haydenbleasel/favicons/issues/61) and the [Windows tile silhouette ability](https://github.com/haydenbleasel/favicons/issues/58) both require [SVG support](https://github.com/haydenbleasel/favicons/issues/53). If modules for these task begin to appear, please jump on the appropriate issue and we'll get on it ASAP.
+
+> What is the difference between apple and appleIcon?
+
+See webhint explanation on why a single 180x180 touch icon might be the best solution: [https://webhint.io/docs/user-guide/hints/hint-apple-touch-icons/](https://webhint.io/docs/user-guide/hints/hint-apple-touch-icons/):
+
+Over time as Apple released different size displays for their devices, the requirements for the size of the touch icon have changed quite a bit \[...\]. Declaring one 180×180px PNG image, e.g.:
+
+```html
+<link rel="apple-touch-icon" href="apple-touch-icon.png">
+```
+
+in the <head> of the page is enough, and including all the different sizes is not recommended as:
+
+- It will increase the size of the pages with very little to no real benefit (most users will probably not add the site to their home screens).
+
+- Most sizes will probably never be used as iOS devices get upgraded quickly, so [most iOS users will be on the latest 2 versions of iOS]app store stats and using newer devices.
+
+- The 180×180px image, if needed, [will be automatically downscaled by Safari, and the result of the scaling is generally ok][icon scaling].
+
+The only downside to using one icon is that some users will load a larger image, while a much smaller file would have worked just as well. But the chance of that happening decreases with every day as users upgrade their devices and their iOS version.
 
 ## Thank you
 

--- a/src/config/defaults.json
+++ b/src/config/defaults.json
@@ -20,6 +20,7 @@
   "manifestRelativePaths": false,
   "icons": {
     "android": true,
+    "apple": false,
     "appleIcon": true,
     "appleStartup": true,
     "coast": true,

--- a/src/config/html.js
+++ b/src/config/html.js
@@ -9,6 +9,12 @@ module.exports = {
     ({ theme_color, background }) => `<meta name="theme-color" content="${theme_color || background}">`,
     ({ appName }) => appName ? `<meta name="application-name" content="${appName}">` : `<meta name="application-name">`
   ],
+  apple: [
+    ({ relative }) => `<link rel="apple-touch-icon" sizes="180x180" href="${relative("apple-touch-icon.png")}">`,
+    () => `<meta name="apple-mobile-web-app-capable" content="yes">`,
+    ({ appleStatusBarStyle }) => `<meta name="apple-mobile-web-app-status-bar-style" content="${appleStatusBarStyle}">`,
+    ({ appShortName, appName }) => (appShortName || appName) ? `<meta name="apple-mobile-web-app-title" content="${appShortName || appName}">` : `<meta name="apple-mobile-web-app-title">`
+  ],
   appleIcon: [
     ({ relative }) => `<link rel="apple-touch-icon" sizes="57x57" href="${relative("apple-touch-icon-57x57.png")}">`,
     ({ relative }) => `<link rel="apple-touch-icon" sizes="60x60" href="${relative("apple-touch-icon-60x60.png")}">`,

--- a/src/config/icons.json
+++ b/src/config/icons.json
@@ -64,6 +64,15 @@
       "mask": false
     }
   },
+  "apple": {
+    "apple-touch-icon.png": {
+      "width": 180,
+      "height": 180,
+      "transparent": false,
+      "rotate": false,
+      "mask": false
+    }
+  },
   "appleIcon": {
     "apple-touch-icon-57x57.png": {
       "width": 57,

--- a/src/config/platform-options.json
+++ b/src/config/platform-options.json
@@ -1,10 +1,11 @@
 {
 	"offset": {
-		"platforms": ["android", "appleIcon", "appleStartup", "firefox", "coast", "windows", "yandex", "favicons"],
+		"platforms": ["android", "apple", "appleIcon", "appleStartup", "firefox", "coast", "windows", "yandex", "favicons"],
 		"defaultTo": 0
 	},
 	"background": {
-		"platforms": ["android", "appleIcon", "appleStartup", "firefox", "coast", "windows", "yandex", "favicons"],
+		"platforms": ["android", "apple", "appleIcon", "appleStartup", "firefox", "coast", "windows", "yandex", "favicons"],
+		"apple": true,
 		"appleIcon": true,
 		"appleStartup": true,
 		"firefox": true,
@@ -12,17 +13,17 @@
 		"defaultTo": false
 	},
 	"mask": {
-		"platforms": ["android", "appleIcon", "appleStartup", "firefox", "coast", "windows", "yandex", "favicons"],
+		"platforms": ["android", "apple", "appleIcon", "appleStartup", "firefox", "coast", "windows", "yandex", "favicons"],
 		"firefox": true,
 		"defaultTo": false
 	},
 	"overlayGlow": {
-		"platforms": ["android", "appleIcon", "appleStartup", "firefox", "coast", "windows", "yandex", "favicons"],
+		"platforms": ["android", "apple", "appleIcon", "appleStartup", "firefox", "coast", "windows", "yandex", "favicons"],
 		"firefox": true,
 		"defaultTo": false
 	},
 	"overlayShadow": {
-		"platforms": ["android", "appleIcon", "appleStartup", "firefox", "coast", "windows", "yandex", "favicons"],
+		"platforms": ["android", "apple", "appleIcon", "appleStartup", "firefox", "coast", "windows", "yandex", "favicons"],
 		"defaultTo": false
 	}
 }

--- a/test/createExamples.js
+++ b/test/createExamples.js
@@ -30,7 +30,8 @@ const favicons = require('../dist/index.js'),
         loadManifestWithCredentials: false,       // Browsers don't send cookies when fetching a manifest, enable this to fix that. `boolean`
         icons: {
             android: true,              // Create Android homescreen icon. `boolean` or `{ offset, background, mask, overlayGlow, overlayShadow }`
-            appleIcon: true,            // Create Apple touch icons. `boolean` or `{ offset, background, mask, overlayGlow, overlayShadow }`
+            apple: true,                // Create a single Apple touch icon (180x180). `boolean` or `{ offset, background, mask, overlayGlow, overlayShadow }`
+            appleIcon: true,            // Create all Apple touch icons. `boolean` or `{ offset, background, mask, overlayGlow, overlayShadow }`
             appleStartup: true,         // Create Apple startup images. `boolean` or `{ offset, background, mask, overlayGlow, overlayShadow }`
             coast: true,                // Create Opera Coast icon. `boolean` or `{ offset, background, mask, overlayGlow, overlayShadow }`
             favicons: true,             // Create regular favicons. `boolean` or `{ offset, background, mask, overlayGlow, overlayShadow }`

--- a/test/loadManifestWithCredentials.test.js
+++ b/test/loadManifestWithCredentials.test.js
@@ -16,6 +16,7 @@ test("should add crossOrigin to manifest tag when loadManifestWithCredentials is
     loadManifestWithCredentials: true,
     icons: {
       android: true,
+      apple: false,
       appleIcon: false,
       appleStartup: false,
       coast: false,

--- a/test/manifestRelativePaths.test.js
+++ b/test/manifestRelativePaths.test.js
@@ -20,6 +20,7 @@ test("should images without options.path to manifests when manifestRelativePaths
       firefox: true,
       windows: true,
       yandex: true,
+      apple: false,
       appleIcon: false,
       appleStartup: false,
       coast: false,

--- a/test/noassets.test.js
+++ b/test/noassets.test.js
@@ -10,6 +10,7 @@ test("should allow disabling asset generation", async t => {
   const { files, images, html } = await favicons(logo_png, {
     icons: {
       android: false,
+      apple: false,
       appleIcon: false,
       appleStartup: false,
       coast: false,

--- a/test/overlayshadow.test.js
+++ b/test/overlayshadow.test.js
@@ -19,6 +19,7 @@ test("should allow configuring 'overlayShadow'", async t => {
         mask: true,
         overlayShadow: true
       },
+      apple: false,
       appleIcon: false,
       appleStartup: false,
       coast: false,

--- a/test/svgScaling.test.js
+++ b/test/svgScaling.test.js
@@ -7,6 +7,7 @@ const { logo_small_svg } = require("./util");
 // difference between the generated files.
 const icons = {
   android: false,
+  apple: false,
   appleIcon: true,
   appleStartup: false,
   coast: false,


### PR DESCRIPTION
- set default to false
- add platform to html
- add config icon
- add to all platform option
- include apple platform in tests
- update readme with explanation from webhint

This PR add a new platform: `apple` and takes care of generating a single icon image for apple devices (`<link rel="apple-touch-icon" href="apple-touch-icon.png">`. It follows the recommendation from webhint and lighthouse to have a single image instead of the dozen currently generated by the `appleIcon` platform:
- https://webhint.io/docs/user-guide/hints/hint-apple-touch-icons/
- https://web.dev/apple-touch-icon/

I went the separate platform way instead of a `onlyNewAppleSizes` option as suggested in  @evilebottnawi comment (https://github.com/itgalaxy/favicons/issues/130#issuecomment-563276162) as it seems to be the new norm, it's quite specific to the apple platform and I see it as exclusive from the current appleIcon support that might disappear. Let me know if that makes sense!

Close #130 
Close #198 