### PR TITLE
FIX: escape dangerous appName and appShortName in HTML.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3667,6 +3667,11 @@
       "integrity": "sha512-8/uIhbG12Csjy2JEW7D9pHbreaVaS/OpN3ycnyvElTdwM5n6GY6W6e2IPemfvGZeUMqZ9A/3GqIZMgKnBhAw/Q==",
       "dev": true
     },
+    "escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg="
+    },
     "escape-string-regexp": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
@@ -9016,6 +9021,7 @@
             "jpeg-js": "^0.2.0",
             "load-bmfont": "^1.2.3",
             "mime": "^1.3.4",
+            "mkdirp": "0.5.1",
             "pixelmatch": "^4.0.0",
             "pngjs": "^3.0.0",
             "read-chunk": "^1.0.1",
@@ -9049,6 +9055,19 @@
           "version": "0.1.2",
           "resolved": "https://registry.npmjs.org/jpeg-js/-/jpeg-js-0.1.2.tgz",
           "integrity": "sha1-E1uZLAV1yYXPoPSUoyJ+0jhYPs4="
+        },
+        "minimist": {
+          "version": "0.0.8",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
+        },
+        "mkdirp": {
+          "version": "0.5.1",
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+          "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+          "requires": {
+            "minimist": "0.0.8"
+          }
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
   "dependencies": {
     "clone": "^2.1.2",
     "colors": "^1.4.0",
+    "escape-html": "^1.0.3",
     "image-size": "^0.8.3",
     "jimp": "^0.10.3",
     "jsontoxml": "^1.0.1",

--- a/src/config/html.js
+++ b/src/config/html.js
@@ -1,4 +1,7 @@
 // prettier-ignore
+
+const escapeHtml = require('escape-html');
+
 module.exports = {
   android: [
     ({ relative, loadManifestWithCredentials }) =>
@@ -7,7 +10,7 @@ module.exports = {
         : `<link rel="manifest" href="${relative("manifest.json")}">`,
     () => `<meta name="mobile-web-app-capable" content="yes">`,
     ({ theme_color, background }) => `<meta name="theme-color" content="${theme_color || background}">`,
-    ({ appName }) => appName ? `<meta name="application-name" content="${appName}">` : `<meta name="application-name">`
+    ({ appName }) => appName ? `<meta name="application-name" content="${escapeHtml(appName)}">` : `<meta name="application-name">`
   ],
   appleIcon: [
     ({ relative }) => `<link rel="apple-touch-icon" sizes="57x57" href="${relative("apple-touch-icon-57x57.png")}">`,
@@ -23,7 +26,7 @@ module.exports = {
     ({ relative }) => `<link rel="apple-touch-icon" sizes="1024x1024" href="${relative("apple-touch-icon-1024x1024.png")}">`,
     () => `<meta name="apple-mobile-web-app-capable" content="yes">`,
     ({ appleStatusBarStyle }) => `<meta name="apple-mobile-web-app-status-bar-style" content="${appleStatusBarStyle}">`,
-    ({ appShortName, appName }) => (appShortName || appName) ? `<meta name="apple-mobile-web-app-title" content="${appShortName || appName}">` : `<meta name="apple-mobile-web-app-title">`
+    ({ appShortName, appName }) => (appShortName || appName) ? `<meta name="apple-mobile-web-app-title" content="${escapeHtml(appShortName || appName)}">` : `<meta name="apple-mobile-web-app-title">`
   ],
   appleStartup: [
     //


### PR DESCRIPTION
Fixes #316 

Escaping characters in appName and appShortName when used in HTML.

There maybe other instances in HTML that need escaping.