### PR TITLE
FIX: escape dangerous appName and appShortName in HTML.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4803,6 +4803,11 @@
       "integrity": "sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==",
       "dev": true
     },
+    "escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg="
+    },
     "escape-string-regexp": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
   "dependencies": {
     "clone": "^2.1.2",
     "colors": "^1.4.0",
+    "escape-html": "^1.0.3",
     "image-size": "^1.0.0",
     "jsontoxml": "^1.0.1",
     "lodash.defaultsdeep": "^4.6.1",

--- a/src/config/html.js
+++ b/src/config/html.js
@@ -1,4 +1,5 @@
 /* eslint-disable */
+const escapeHtml = require("escape-html");
 
 const appleIconSizes = [57, 60, 72, 76, 114, 120, 144, 152, 167, 180, 1024];
 
@@ -283,13 +284,13 @@ module.exports = {
         : `<link rel="manifest" href="${relative("manifest.json")}">`,
     () => `<meta name="mobile-web-app-capable" content="yes">`,
     ({ theme_color, background }) => `<meta name="theme-color" content="${theme_color || background}">`,
-    ({ appName }) => appName ? `<meta name="application-name" content="${appName}">` : `<meta name="application-name">`
+    ({ appName }) => appName ? `<meta name="application-name" content="${escapeHtml(appName)}">` : `<meta name="application-name">`
   ],
   appleIcon: [
     ...appleIconSizes.map(size => ctx => appleIconGen(size, ctx)),
     () => `<meta name="apple-mobile-web-app-capable" content="yes">`,
     ({ appleStatusBarStyle }) => `<meta name="apple-mobile-web-app-status-bar-style" content="${appleStatusBarStyle}">`,
-    ({ appShortName, appName }) => (appShortName || appName) ? `<meta name="apple-mobile-web-app-title" content="${appShortName || appName}">` : `<meta name="apple-mobile-web-app-title">`
+    ({ appShortName, appName }) => (appShortName || appName) ? `<meta name="apple-mobile-web-app-title" content="${escapeHtml(appShortName || appName)}">` : `<meta name="apple-mobile-web-app-title">`
   ],
   appleStartup: appleStartupItems.map(item => ctx => appleStartupGen(item, ctx)),
   coast: coastSizes.map(size => ctx => coastGen(size, ctx)),


### PR DESCRIPTION
Supersedes #317

Closes #316
Closes #317