### PR TITLE
Allow to rename files (manifests)

### DIFF
--- a/src/config/defaults.ts
+++ b/src/config/defaults.ts
@@ -18,6 +18,10 @@ export interface IconOptions {
   readonly pixelArt?: boolean;
 }
 
+export interface FileOptions {
+  readonly manifestFileName?: string;
+}
+
 export interface Application {
   readonly platform?: string;
   readonly url?: string;
@@ -55,6 +59,7 @@ export interface FaviconOptions {
   readonly preferRelatedApplications?: boolean;
   readonly relatedApplications?: Application[];
   readonly icons?: Dictionary<IconOptions | boolean | string[]>;
+  readonly files?: Dictionary<FileOptions>;
   readonly output?: OutputOptions;
 }
 

--- a/src/platforms/firefox.ts
+++ b/src/platforms/firefox.ts
@@ -34,7 +34,7 @@ function firefoxManifest(
   }
 
   return {
-    name: "manifest.webapp",
+    name: options.files?.firefox?.manifestFileName ?? "manifest.webapp",
     contents: JSON.stringify(properties, null, 2),
   };
 }

--- a/src/platforms/yandex.ts
+++ b/src/platforms/yandex.ts
@@ -9,30 +9,6 @@ const ICONS_OPTIONS: Dictionary<IconOptions> = {
   "yandex-browser-50x50.png": transparentIcon(50),
 };
 
-function yandexManifest(
-  options: FaviconOptions,
-  iconOptions: Dictionary<IconOptions>
-): FaviconFile {
-  const basePath = options.manifestRelativePaths ? null : options.path;
-
-  const logo = Object.keys(iconOptions)[0];
-
-  const properties = {
-    version: options.version,
-    api_version: 1,
-    layout: {
-      logo: relativeTo(basePath, logo),
-      color: options.background,
-      show_title: true,
-    },
-  };
-
-  return {
-    name: "yandex-browser-manifest.json",
-    contents: JSON.stringify(properties, null, 2),
-  };
-}
-
 export class YandexPlatform extends Platform {
   constructor(options: FaviconOptions, logger: Logger) {
     super(
@@ -43,13 +19,43 @@ export class YandexPlatform extends Platform {
   }
 
   async createFiles(): Promise<FaviconFile[]> {
-    return [yandexManifest(this.options, this.iconOptions)];
+    return [this.manifest()];
   }
 
   async createHtml(): Promise<FaviconHtmlElement[]> {
     // prettier-ignore
     return [
-      `<link rel="yandex-tableau-widget" href="${this.relative("yandex-browser-manifest.json")}">`
+      `<link rel="yandex-tableau-widget" href="${this.relative(this.manifestFileName())}">`
     ];
+  }
+
+  private manifestFileName(): string {
+    return (
+      this.options.files?.yandex?.manifestFileName ??
+      "yandex-browser-manifest.json"
+    );
+  }
+
+  private manifest(): FaviconFile {
+    const basePath = this.options.manifestRelativePaths
+      ? null
+      : this.options.path;
+
+    const logo = Object.keys(this.iconOptions)[0];
+
+    const properties = {
+      version: this.options.version,
+      api_version: 1,
+      layout: {
+        logo: relativeTo(basePath, logo),
+        color: this.options.background,
+        show_title: true,
+      },
+    };
+
+    return {
+      name: this.manifestFileName(),
+      contents: JSON.stringify(properties, null, 2),
+    };
   }
 }

--- a/test/manifest.test.js
+++ b/test/manifest.test.js
@@ -50,3 +50,41 @@ it("should list preferrable related applications", async () => {
   expect(manifest).toHaveProperty("prefer_related_applications");
   expect(manifest.related_applications).toStrictEqual(relatedApplications);
 });
+
+it("should allow renaming of manifest", async () => {
+  // expect.assertions(2);
+
+  const result = await favicons(logo_png, {
+    output: { images: false, html: false },
+  });
+  const filenames = result.files.map((file) => file.name);
+
+  expect(new Set(filenames)).toEqual(
+    new Set([
+      "manifest.json",
+      "manifest.webapp",
+      "browserconfig.xml",
+      "yandex-browser-manifest.json",
+    ])
+  );
+
+  const result2 = await favicons(logo_png, {
+    output: { images: false, html: false },
+    files: {
+      android: { manifestFileName: "android-manifest.json" },
+      firefox: { manifestFileName: "firefox-manifest.webapp" },
+      windows: { manifestFileName: "windows-browserconfig.xml" },
+      yandex: { manifestFileName: "yandex-manifest.json" },
+    },
+  });
+  const filenames2 = result2.files.map((file) => file.name);
+
+  expect(new Set(filenames2)).toEqual(
+    new Set([
+      "android-manifest.json",
+      "firefox-manifest.webapp",
+      "windows-browserconfig.xml",
+      "yandex-manifest.json",
+    ])
+  );
+});


### PR DESCRIPTION
Addresses #354 and #280.

This change looks big, but actually functions which generate manifests/configs were just moved inside corresponding platform classes.