### PR TITLE
Rename manifest.json to manifest.webmanifest

### DIFF
--- a/src/platforms/android.ts
+++ b/src/platforms/android.ts
@@ -98,7 +98,9 @@ export class AndroidPlatform extends Platform {
   }
 
   private manifestFileName(): string {
-    return this.options.files?.android?.manifestFileName ?? "manifest.json";
+    return (
+      this.options.files?.android?.manifestFileName ?? "manifest.webmanifest"
+    );
   }
 
   private manifest(): FaviconFile {

--- a/test/__snapshots__/array.test.js.snap
+++ b/test/__snapshots__/array.test.js.snap
@@ -72,7 +72,7 @@ Object {
     }
   ]
 }",
-      "name": "manifest.json",
+      "name": "manifest.webmanifest",
     },
     Object {
       "contents": "<?xml version=\\"1.0\\" encoding=\\"utf-8\\"?>
@@ -107,7 +107,7 @@ Object {
     "<link rel=\\"icon\\" type=\\"image/png\\" sizes=\\"16x16\\" href=\\"/favicon-16x16.png\\">",
     "<link rel=\\"icon\\" type=\\"image/png\\" sizes=\\"32x32\\" href=\\"/favicon-32x32.png\\">",
     "<link rel=\\"icon\\" type=\\"image/png\\" sizes=\\"48x48\\" href=\\"/favicon-48x48.png\\">",
-    "<link rel=\\"manifest\\" href=\\"/manifest.json\\">",
+    "<link rel=\\"manifest\\" href=\\"/manifest.webmanifest\\">",
     "<meta name=\\"mobile-web-app-capable\\" content=\\"yes\\">",
     "<meta name=\\"theme-color\\" content=\\"#fff\\">",
     "<meta name=\\"application-name\\">",
@@ -465,7 +465,7 @@ Object {
     }
   ]
 }",
-      "name": "manifest.json",
+      "name": "manifest.webmanifest",
     },
     Object {
       "contents": "<?xml version=\\"1.0\\" encoding=\\"utf-8\\"?>
@@ -500,7 +500,7 @@ Object {
     "<link rel=\\"icon\\" type=\\"image/png\\" sizes=\\"16x16\\" href=\\"/favicon-16x16.png\\">",
     "<link rel=\\"icon\\" type=\\"image/png\\" sizes=\\"32x32\\" href=\\"/favicon-32x32.png\\">",
     "<link rel=\\"icon\\" type=\\"image/png\\" sizes=\\"48x48\\" href=\\"/favicon-48x48.png\\">",
-    "<link rel=\\"manifest\\" href=\\"/manifest.json\\">",
+    "<link rel=\\"manifest\\" href=\\"/manifest.webmanifest\\">",
     "<meta name=\\"mobile-web-app-capable\\" content=\\"yes\\">",
     "<meta name=\\"theme-color\\" content=\\"#fff\\">",
     "<meta name=\\"application-name\\">",

--- a/test/__snapshots__/background.test.js.snap
+++ b/test/__snapshots__/background.test.js.snap
@@ -72,7 +72,7 @@ Object {
     }
   ]
 }",
-      "name": "manifest.json",
+      "name": "manifest.webmanifest",
     },
     Object {
       "contents": "<?xml version=\\"1.0\\" encoding=\\"utf-8\\"?>
@@ -107,7 +107,7 @@ Object {
     "<link rel=\\"icon\\" type=\\"image/png\\" sizes=\\"16x16\\" href=\\"/favicon-16x16.png\\">",
     "<link rel=\\"icon\\" type=\\"image/png\\" sizes=\\"32x32\\" href=\\"/favicon-32x32.png\\">",
     "<link rel=\\"icon\\" type=\\"image/png\\" sizes=\\"48x48\\" href=\\"/favicon-48x48.png\\">",
-    "<link rel=\\"manifest\\" href=\\"/manifest.json\\">",
+    "<link rel=\\"manifest\\" href=\\"/manifest.webmanifest\\">",
     "<meta name=\\"mobile-web-app-capable\\" content=\\"yes\\">",
     "<meta name=\\"theme-color\\" content=\\"#fff\\">",
     "<meta name=\\"application-name\\">",

--- a/test/__snapshots__/default.test.js.snap
+++ b/test/__snapshots__/default.test.js.snap
@@ -72,7 +72,7 @@ Object {
     }
   ]
 }",
-      "name": "manifest.json",
+      "name": "manifest.webmanifest",
     },
     Object {
       "contents": "<?xml version=\\"1.0\\" encoding=\\"utf-8\\"?>
@@ -107,7 +107,7 @@ Object {
     "<link rel=\\"icon\\" type=\\"image/png\\" sizes=\\"16x16\\" href=\\"/favicon-16x16.png\\">",
     "<link rel=\\"icon\\" type=\\"image/png\\" sizes=\\"32x32\\" href=\\"/favicon-32x32.png\\">",
     "<link rel=\\"icon\\" type=\\"image/png\\" sizes=\\"48x48\\" href=\\"/favicon-48x48.png\\">",
-    "<link rel=\\"manifest\\" href=\\"/manifest.json\\">",
+    "<link rel=\\"manifest\\" href=\\"/manifest.webmanifest\\">",
     "<meta name=\\"mobile-web-app-capable\\" content=\\"yes\\">",
     "<meta name=\\"theme-color\\" content=\\"#fff\\">",
     "<meta name=\\"application-name\\">",

--- a/test/__snapshots__/loadManifestWithCredentials.test.js.snap
+++ b/test/__snapshots__/loadManifestWithCredentials.test.js.snap
@@ -72,11 +72,11 @@ Object {
     }
   ]
 }",
-      "name": "manifest.json",
+      "name": "manifest.webmanifest",
     },
   ],
   "html": Array [
-    "<link rel=\\"manifest\\" href=\\"/manifest.json\\" crossOrigin=\\"use-credentials\\">",
+    "<link rel=\\"manifest\\" href=\\"/manifest.webmanifest\\" crossOrigin=\\"use-credentials\\">",
     "<meta name=\\"mobile-web-app-capable\\" content=\\"yes\\">",
     "<meta name=\\"theme-color\\" content=\\"#fff\\">",
     "<meta name=\\"application-name\\">",

--- a/test/__snapshots__/manifestMaskable.test.js.snap
+++ b/test/__snapshots__/manifestMaskable.test.js.snap
@@ -126,7 +126,7 @@ Object {
     }
   ]
 }",
-      "name": "manifest.json",
+      "name": "manifest.webmanifest",
     },
     Object {
       "contents": "<?xml version=\\"1.0\\" encoding=\\"utf-8\\"?>
@@ -161,7 +161,7 @@ Object {
     "<link rel=\\"icon\\" type=\\"image/png\\" sizes=\\"16x16\\" href=\\"/favicon-16x16.png\\">",
     "<link rel=\\"icon\\" type=\\"image/png\\" sizes=\\"32x32\\" href=\\"/favicon-32x32.png\\">",
     "<link rel=\\"icon\\" type=\\"image/png\\" sizes=\\"48x48\\" href=\\"/favicon-48x48.png\\">",
-    "<link rel=\\"manifest\\" href=\\"/manifest.json\\">",
+    "<link rel=\\"manifest\\" href=\\"/manifest.webmanifest\\">",
     "<meta name=\\"mobile-web-app-capable\\" content=\\"yes\\">",
     "<meta name=\\"theme-color\\" content=\\"#fff\\">",
     "<meta name=\\"application-name\\">",
@@ -555,7 +555,7 @@ Object {
     }
   ]
 }",
-      "name": "manifest.json",
+      "name": "manifest.webmanifest",
     },
     Object {
       "contents": "<?xml version=\\"1.0\\" encoding=\\"utf-8\\"?>
@@ -590,7 +590,7 @@ Object {
     "<link rel=\\"icon\\" type=\\"image/png\\" sizes=\\"16x16\\" href=\\"/favicon-16x16.png\\">",
     "<link rel=\\"icon\\" type=\\"image/png\\" sizes=\\"32x32\\" href=\\"/favicon-32x32.png\\">",
     "<link rel=\\"icon\\" type=\\"image/png\\" sizes=\\"48x48\\" href=\\"/favicon-48x48.png\\">",
-    "<link rel=\\"manifest\\" href=\\"/manifest.json\\">",
+    "<link rel=\\"manifest\\" href=\\"/manifest.webmanifest\\">",
     "<meta name=\\"mobile-web-app-capable\\" content=\\"yes\\">",
     "<meta name=\\"theme-color\\" content=\\"#fff\\">",
     "<meta name=\\"application-name\\">",

--- a/test/__snapshots__/manifestRelativePaths.test.js.snap
+++ b/test/__snapshots__/manifestRelativePaths.test.js.snap
@@ -72,7 +72,7 @@ Object {
     }
   ]
 }",
-      "name": "manifest.json",
+      "name": "manifest.webmanifest",
     },
     Object {
       "contents": "<?xml version=\\"1.0\\" encoding=\\"utf-8\\"?>
@@ -103,7 +103,7 @@ Object {
     },
   ],
   "html": Array [
-    "<link rel=\\"manifest\\" href=\\"/favicons/manifest.json\\">",
+    "<link rel=\\"manifest\\" href=\\"/favicons/manifest.webmanifest\\">",
     "<meta name=\\"mobile-web-app-capable\\" content=\\"yes\\">",
     "<meta name=\\"theme-color\\" content=\\"#fff\\">",
     "<meta name=\\"application-name\\">",

--- a/test/__snapshots__/meta.test.js.snap
+++ b/test/__snapshots__/meta.test.js.snap
@@ -73,7 +73,7 @@ Object {
     }
   ]
 }",
-      "name": "manifest.json",
+      "name": "manifest.webmanifest",
     },
     Object {
       "contents": "<?xml version=\\"1.0\\" encoding=\\"utf-8\\"?>
@@ -108,7 +108,7 @@ Object {
     "<link rel=\\"icon\\" type=\\"image/png\\" sizes=\\"16x16\\" href=\\"/favicon-16x16.png\\">",
     "<link rel=\\"icon\\" type=\\"image/png\\" sizes=\\"32x32\\" href=\\"/favicon-32x32.png\\">",
     "<link rel=\\"icon\\" type=\\"image/png\\" sizes=\\"48x48\\" href=\\"/favicon-48x48.png\\">",
-    "<link rel=\\"manifest\\" href=\\"/manifest.json\\">",
+    "<link rel=\\"manifest\\" href=\\"/manifest.webmanifest\\">",
     "<meta name=\\"mobile-web-app-capable\\" content=\\"yes\\">",
     "<meta name=\\"theme-color\\" content=\\"#abc\\">",
     "<meta name=\\"application-name\\" content=\\"PWA\\">",

--- a/test/__snapshots__/offset.test.js.snap
+++ b/test/__snapshots__/offset.test.js.snap
@@ -72,7 +72,7 @@ Object {
     }
   ]
 }",
-      "name": "manifest.json",
+      "name": "manifest.webmanifest",
     },
     Object {
       "contents": "<?xml version=\\"1.0\\" encoding=\\"utf-8\\"?>
@@ -107,7 +107,7 @@ Object {
     "<link rel=\\"icon\\" type=\\"image/png\\" sizes=\\"16x16\\" href=\\"/favicon-16x16.png\\">",
     "<link rel=\\"icon\\" type=\\"image/png\\" sizes=\\"32x32\\" href=\\"/favicon-32x32.png\\">",
     "<link rel=\\"icon\\" type=\\"image/png\\" sizes=\\"48x48\\" href=\\"/favicon-48x48.png\\">",
-    "<link rel=\\"manifest\\" href=\\"/manifest.json\\">",
+    "<link rel=\\"manifest\\" href=\\"/manifest.webmanifest\\">",
     "<meta name=\\"mobile-web-app-capable\\" content=\\"yes\\">",
     "<meta name=\\"theme-color\\" content=\\"#fff\\">",
     "<meta name=\\"application-name\\">",

--- a/test/__snapshots__/pixelart.test.js.snap
+++ b/test/__snapshots__/pixelart.test.js.snap
@@ -72,7 +72,7 @@ Object {
     }
   ]
 }",
-      "name": "manifest.json",
+      "name": "manifest.webmanifest",
     },
     Object {
       "contents": "<?xml version=\\"1.0\\" encoding=\\"utf-8\\"?>
@@ -107,7 +107,7 @@ Object {
     "<link rel=\\"icon\\" type=\\"image/png\\" sizes=\\"16x16\\" href=\\"/favicon-16x16.png\\">",
     "<link rel=\\"icon\\" type=\\"image/png\\" sizes=\\"32x32\\" href=\\"/favicon-32x32.png\\">",
     "<link rel=\\"icon\\" type=\\"image/png\\" sizes=\\"48x48\\" href=\\"/favicon-48x48.png\\">",
-    "<link rel=\\"manifest\\" href=\\"/manifest.json\\">",
+    "<link rel=\\"manifest\\" href=\\"/manifest.webmanifest\\">",
     "<meta name=\\"mobile-web-app-capable\\" content=\\"yes\\">",
     "<meta name=\\"theme-color\\" content=\\"#fff\\">",
     "<meta name=\\"application-name\\">",

--- a/test/__snapshots__/prefixed.test.js.snap
+++ b/test/__snapshots__/prefixed.test.js.snap
@@ -72,7 +72,7 @@ Object {
     }
   ]
 }",
-      "name": "manifest.json",
+      "name": "manifest.webmanifest",
     },
     Object {
       "contents": "<?xml version=\\"1.0\\" encoding=\\"utf-8\\"?>
@@ -107,7 +107,7 @@ Object {
     "<link rel=\\"icon\\" type=\\"image/png\\" sizes=\\"16x16\\" href=\\"https://domain/subdomain/favicon-16x16.png\\">",
     "<link rel=\\"icon\\" type=\\"image/png\\" sizes=\\"32x32\\" href=\\"https://domain/subdomain/favicon-32x32.png\\">",
     "<link rel=\\"icon\\" type=\\"image/png\\" sizes=\\"48x48\\" href=\\"https://domain/subdomain/favicon-48x48.png\\">",
-    "<link rel=\\"manifest\\" href=\\"https://domain/subdomain/manifest.json\\">",
+    "<link rel=\\"manifest\\" href=\\"https://domain/subdomain/manifest.webmanifest\\">",
     "<meta name=\\"mobile-web-app-capable\\" content=\\"yes\\">",
     "<meta name=\\"theme-color\\" content=\\"#fff\\">",
     "<meta name=\\"application-name\\">",

--- a/test/__snapshots__/stream.test.js.snap
+++ b/test/__snapshots__/stream.test.js.snap
@@ -1445,7 +1445,7 @@ Object {
         ],
         "type": "Buffer",
       },
-      "name": "manifest.json",
+      "name": "manifest.webmanifest",
     },
     Object {
       "contents": Object {
@@ -2220,7 +2220,7 @@ Object {
     "<link rel=\\"icon\\" type=\\"image/png\\" sizes=\\"16x16\\" href=\\"/favicon-16x16.png\\">",
     "<link rel=\\"icon\\" type=\\"image/png\\" sizes=\\"32x32\\" href=\\"/favicon-32x32.png\\">",
     "<link rel=\\"icon\\" type=\\"image/png\\" sizes=\\"48x48\\" href=\\"/favicon-48x48.png\\">",
-    "<link rel=\\"manifest\\" href=\\"/manifest.json\\">",
+    "<link rel=\\"manifest\\" href=\\"/manifest.webmanifest\\">",
     "<meta name=\\"mobile-web-app-capable\\" content=\\"yes\\">",
     "<meta name=\\"theme-color\\" content=\\"#fff\\">",
     "<meta name=\\"application-name\\">",

--- a/test/__snapshots__/svg.test.js.snap
+++ b/test/__snapshots__/svg.test.js.snap
@@ -72,7 +72,7 @@ Object {
     }
   ]
 }",
-      "name": "manifest.json",
+      "name": "manifest.webmanifest",
     },
     Object {
       "contents": "<?xml version=\\"1.0\\" encoding=\\"utf-8\\"?>
@@ -107,7 +107,7 @@ Object {
     "<link rel=\\"icon\\" type=\\"image/png\\" sizes=\\"16x16\\" href=\\"/favicon-16x16.png\\">",
     "<link rel=\\"icon\\" type=\\"image/png\\" sizes=\\"32x32\\" href=\\"/favicon-32x32.png\\">",
     "<link rel=\\"icon\\" type=\\"image/png\\" sizes=\\"48x48\\" href=\\"/favicon-48x48.png\\">",
-    "<link rel=\\"manifest\\" href=\\"/manifest.json\\">",
+    "<link rel=\\"manifest\\" href=\\"/manifest.webmanifest\\">",
     "<meta name=\\"mobile-web-app-capable\\" content=\\"yes\\">",
     "<meta name=\\"theme-color\\" content=\\"#fff\\">",
     "<meta name=\\"application-name\\">",

--- a/test/manifest.test.js
+++ b/test/manifest.test.js
@@ -8,7 +8,7 @@ it("should not prefer any related applications by default", async () => {
     output: { images: false, html: false },
   });
   const manifestFile = result.files.find(
-    (file) => file.name === "manifest.json"
+    (file) => file.name === "manifest.webmanifest"
   );
 
   expect(manifestFile).toBeDefined();
@@ -39,7 +39,7 @@ it("should list preferrable related applications", async () => {
     output: { images: false, html: false },
   });
   const manifestFile = result.files.find(
-    (file) => file.name === "manifest.json"
+    (file) => file.name === "manifest.webmanifest"
   );
 
   expect(manifestFile).toBeDefined();
@@ -52,7 +52,7 @@ it("should list preferrable related applications", async () => {
 });
 
 it("should allow renaming of manifest", async () => {
-  // expect.assertions(2);
+  expect.assertions(2);
 
   const result = await favicons(logo_png, {
     output: { images: false, html: false },
@@ -61,7 +61,7 @@ it("should allow renaming of manifest", async () => {
 
   expect(new Set(filenames)).toEqual(
     new Set([
-      "manifest.json",
+      "manifest.webmanifest",
       "browserconfig.xml",
       "yandex-browser-manifest.json",
     ])
@@ -70,7 +70,7 @@ it("should allow renaming of manifest", async () => {
   const result2 = await favicons(logo_png, {
     output: { images: false, html: false },
     files: {
-      android: { manifestFileName: "android-manifest.json" },
+      android: { manifestFileName: "android-manifest.webmanifest" },
       windows: { manifestFileName: "windows-browserconfig.xml" },
       yandex: { manifestFileName: "yandex-manifest.json" },
     },
@@ -79,7 +79,7 @@ it("should allow renaming of manifest", async () => {
 
   expect(new Set(filenames2)).toEqual(
     new Set([
-      "android-manifest.json",
+      "android-manifest.webmanifest",
       "windows-browserconfig.xml",
       "yandex-manifest.json",
     ])


### PR DESCRIPTION
It seems `.webmanifest` is a preferable extension these days.
It was reported in #280 and https://github.com/jantimon/favicons-webpack-plugin/issues/272