### PR TITLE
fix: remove non standard rel=shortcut

### DIFF
--- a/src/platforms/favicons.ts
+++ b/src/platforms/favicons.ts
@@ -22,7 +22,9 @@ export class FaviconsPlatform extends Platform {
   async createHtml(): Promise<FaviconHtmlElement[]> {
     return Object.entries(this.iconOptions).map(([name, options]) => {
       if (name.endsWith(".ico")) {
-        return `<link rel="shortcut icon" href="${this.relative(name)}">`;
+        return `<link rel="icon" type="image/x-icon" href="${this.relative(
+          name
+        )}">`;
       }
 
       const { width, height } = options.sizes[0];

--- a/test/__snapshots__/array.test.js.snap
+++ b/test/__snapshots__/array.test.js.snap
@@ -103,7 +103,7 @@ Object {
     },
   ],
   "html": Array [
-    "<link rel=\\"shortcut icon\\" href=\\"/favicon.ico\\">",
+    "<link rel=\\"icon\\" type=\\"image/x-icon\\" href=\\"/favicon.ico\\">",
     "<link rel=\\"icon\\" type=\\"image/png\\" sizes=\\"16x16\\" href=\\"/favicon-16x16.png\\">",
     "<link rel=\\"icon\\" type=\\"image/png\\" sizes=\\"32x32\\" href=\\"/favicon-32x32.png\\">",
     "<link rel=\\"icon\\" type=\\"image/png\\" sizes=\\"48x48\\" href=\\"/favicon-48x48.png\\">",
@@ -496,7 +496,7 @@ Object {
     },
   ],
   "html": Array [
-    "<link rel=\\"shortcut icon\\" href=\\"/favicon.ico\\">",
+    "<link rel=\\"icon\\" type=\\"image/x-icon\\" href=\\"/favicon.ico\\">",
     "<link rel=\\"icon\\" type=\\"image/png\\" sizes=\\"16x16\\" href=\\"/favicon-16x16.png\\">",
     "<link rel=\\"icon\\" type=\\"image/png\\" sizes=\\"32x32\\" href=\\"/favicon-32x32.png\\">",
     "<link rel=\\"icon\\" type=\\"image/png\\" sizes=\\"48x48\\" href=\\"/favicon-48x48.png\\">",

--- a/test/__snapshots__/background.test.js.snap
+++ b/test/__snapshots__/background.test.js.snap
@@ -103,7 +103,7 @@ Object {
     },
   ],
   "html": Array [
-    "<link rel=\\"shortcut icon\\" href=\\"/favicon.ico\\">",
+    "<link rel=\\"icon\\" type=\\"image/x-icon\\" href=\\"/favicon.ico\\">",
     "<link rel=\\"icon\\" type=\\"image/png\\" sizes=\\"16x16\\" href=\\"/favicon-16x16.png\\">",
     "<link rel=\\"icon\\" type=\\"image/png\\" sizes=\\"32x32\\" href=\\"/favicon-32x32.png\\">",
     "<link rel=\\"icon\\" type=\\"image/png\\" sizes=\\"48x48\\" href=\\"/favicon-48x48.png\\">",

--- a/test/__snapshots__/default.test.js.snap
+++ b/test/__snapshots__/default.test.js.snap
@@ -103,7 +103,7 @@ Object {
     },
   ],
   "html": Array [
-    "<link rel=\\"shortcut icon\\" href=\\"/favicon.ico\\">",
+    "<link rel=\\"icon\\" type=\\"image/x-icon\\" href=\\"/favicon.ico\\">",
     "<link rel=\\"icon\\" type=\\"image/png\\" sizes=\\"16x16\\" href=\\"/favicon-16x16.png\\">",
     "<link rel=\\"icon\\" type=\\"image/png\\" sizes=\\"32x32\\" href=\\"/favicon-32x32.png\\">",
     "<link rel=\\"icon\\" type=\\"image/png\\" sizes=\\"48x48\\" href=\\"/favicon-48x48.png\\">",

--- a/test/__snapshots__/manifestMaskable.test.js.snap
+++ b/test/__snapshots__/manifestMaskable.test.js.snap
@@ -157,7 +157,7 @@ Object {
     },
   ],
   "html": Array [
-    "<link rel=\\"shortcut icon\\" href=\\"/favicon.ico\\">",
+    "<link rel=\\"icon\\" type=\\"image/x-icon\\" href=\\"/favicon.ico\\">",
     "<link rel=\\"icon\\" type=\\"image/png\\" sizes=\\"16x16\\" href=\\"/favicon-16x16.png\\">",
     "<link rel=\\"icon\\" type=\\"image/png\\" sizes=\\"32x32\\" href=\\"/favicon-32x32.png\\">",
     "<link rel=\\"icon\\" type=\\"image/png\\" sizes=\\"48x48\\" href=\\"/favicon-48x48.png\\">",
@@ -586,7 +586,7 @@ Object {
     },
   ],
   "html": Array [
-    "<link rel=\\"shortcut icon\\" href=\\"/favicon.ico\\">",
+    "<link rel=\\"icon\\" type=\\"image/x-icon\\" href=\\"/favicon.ico\\">",
     "<link rel=\\"icon\\" type=\\"image/png\\" sizes=\\"16x16\\" href=\\"/favicon-16x16.png\\">",
     "<link rel=\\"icon\\" type=\\"image/png\\" sizes=\\"32x32\\" href=\\"/favicon-32x32.png\\">",
     "<link rel=\\"icon\\" type=\\"image/png\\" sizes=\\"48x48\\" href=\\"/favicon-48x48.png\\">",

--- a/test/__snapshots__/meta.test.js.snap
+++ b/test/__snapshots__/meta.test.js.snap
@@ -104,7 +104,7 @@ Object {
     },
   ],
   "html": Array [
-    "<link rel=\\"shortcut icon\\" href=\\"/favicon.ico\\">",
+    "<link rel=\\"icon\\" type=\\"image/x-icon\\" href=\\"/favicon.ico\\">",
     "<link rel=\\"icon\\" type=\\"image/png\\" sizes=\\"16x16\\" href=\\"/favicon-16x16.png\\">",
     "<link rel=\\"icon\\" type=\\"image/png\\" sizes=\\"32x32\\" href=\\"/favicon-32x32.png\\">",
     "<link rel=\\"icon\\" type=\\"image/png\\" sizes=\\"48x48\\" href=\\"/favicon-48x48.png\\">",

--- a/test/__snapshots__/offset.test.js.snap
+++ b/test/__snapshots__/offset.test.js.snap
@@ -103,7 +103,7 @@ Object {
     },
   ],
   "html": Array [
-    "<link rel=\\"shortcut icon\\" href=\\"/favicon.ico\\">",
+    "<link rel=\\"icon\\" type=\\"image/x-icon\\" href=\\"/favicon.ico\\">",
     "<link rel=\\"icon\\" type=\\"image/png\\" sizes=\\"16x16\\" href=\\"/favicon-16x16.png\\">",
     "<link rel=\\"icon\\" type=\\"image/png\\" sizes=\\"32x32\\" href=\\"/favicon-32x32.png\\">",
     "<link rel=\\"icon\\" type=\\"image/png\\" sizes=\\"48x48\\" href=\\"/favicon-48x48.png\\">",

--- a/test/__snapshots__/pixelart.test.js.snap
+++ b/test/__snapshots__/pixelart.test.js.snap
@@ -103,7 +103,7 @@ Object {
     },
   ],
   "html": Array [
-    "<link rel=\\"shortcut icon\\" href=\\"/favicon.ico\\">",
+    "<link rel=\\"icon\\" type=\\"image/x-icon\\" href=\\"/favicon.ico\\">",
     "<link rel=\\"icon\\" type=\\"image/png\\" sizes=\\"16x16\\" href=\\"/favicon-16x16.png\\">",
     "<link rel=\\"icon\\" type=\\"image/png\\" sizes=\\"32x32\\" href=\\"/favicon-32x32.png\\">",
     "<link rel=\\"icon\\" type=\\"image/png\\" sizes=\\"48x48\\" href=\\"/favicon-48x48.png\\">",

--- a/test/__snapshots__/prefixed.test.js.snap
+++ b/test/__snapshots__/prefixed.test.js.snap
@@ -103,7 +103,7 @@ Object {
     },
   ],
   "html": Array [
-    "<link rel=\\"shortcut icon\\" href=\\"https://domain/subdomain/favicon.ico\\">",
+    "<link rel=\\"icon\\" type=\\"image/x-icon\\" href=\\"https://domain/subdomain/favicon.ico\\">",
     "<link rel=\\"icon\\" type=\\"image/png\\" sizes=\\"16x16\\" href=\\"https://domain/subdomain/favicon-16x16.png\\">",
     "<link rel=\\"icon\\" type=\\"image/png\\" sizes=\\"32x32\\" href=\\"https://domain/subdomain/favicon-32x32.png\\">",
     "<link rel=\\"icon\\" type=\\"image/png\\" sizes=\\"48x48\\" href=\\"https://domain/subdomain/favicon-48x48.png\\">",

--- a/test/__snapshots__/svg.test.js.snap
+++ b/test/__snapshots__/svg.test.js.snap
@@ -103,7 +103,7 @@ Object {
     },
   ],
   "html": Array [
-    "<link rel=\\"shortcut icon\\" href=\\"/favicon.ico\\">",
+    "<link rel=\\"icon\\" type=\\"image/x-icon\\" href=\\"/favicon.ico\\">",
     "<link rel=\\"icon\\" type=\\"image/png\\" sizes=\\"16x16\\" href=\\"/favicon-16x16.png\\">",
     "<link rel=\\"icon\\" type=\\"image/png\\" sizes=\\"32x32\\" href=\\"/favicon-32x32.png\\">",
     "<link rel=\\"icon\\" type=\\"image/png\\" sizes=\\"48x48\\" href=\\"/favicon-48x48.png\\">",


### PR DESCRIPTION
shortcut is used by IE6 which is dead and not supported anymore by most new frameworks and projects