### PR TITLE
Add feature to set different source image(s) for each platform.

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -48,6 +48,7 @@ const configuration = {
   icons: {
     // Platform Options:
     // - offset - offset in percentage
+    // - source - set different source image(s). `string`, `buffer`, array of `string` or function
     // - background:
     //   * false - use default
     //   * true - force use default, e.g. set background for Android icons

--- a/src/config/defaults.ts
+++ b/src/config/defaults.ts
@@ -1,5 +1,5 @@
 import { PlatformName } from "../platforms";
-import {IconPlaneOptions} from "../helpers";
+import { IconPlaneOptions } from "../helpers";
 
 export interface IconSize {
   readonly width: number;
@@ -9,7 +9,11 @@ export interface IconSize {
 export interface IconOptions {
   readonly sizes: IconSize[];
   readonly offset?: number;
-  readonly source?: string | Buffer | (string | Buffer)[] | ((options:IconPlaneOptions) => string | Buffer | (string | Buffer)[]);
+  readonly source?:
+    | string
+    | Buffer
+    | (string | Buffer)[]
+    | ((options: IconPlaneOptions) => string | Buffer | (string | Buffer)[]);
   readonly background?: string | boolean;
   readonly transparent: boolean;
   readonly rotate: boolean;

--- a/src/config/defaults.ts
+++ b/src/config/defaults.ts
@@ -1,4 +1,5 @@
 import { PlatformName } from "../platforms";
+import {IconPlaneOptions} from "../helpers";
 
 export interface IconSize {
   readonly width: number;
@@ -8,6 +9,7 @@ export interface IconSize {
 export interface IconOptions {
   readonly sizes: IconSize[];
   readonly offset?: number;
+  readonly source?: string | Buffer | (string | Buffer)[] | ((options:IconPlaneOptions) => string | Buffer | (string | Buffer)[]);
   readonly background?: string | boolean;
   readonly transparent: boolean;
   readonly rotate: boolean;

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -18,6 +18,7 @@ export interface IconPlaneOptions {
   readonly background?: string;
   readonly transparent: boolean;
   readonly rotate: boolean;
+  readonly source?: string | Buffer | (string | Buffer)[] | ((options:IconPlaneOptions) => string | Buffer | (string | Buffer)[])
 }
 
 function arrayComparator(a: unknown, b: unknown): number {
@@ -104,6 +105,7 @@ function flattenIconOptions(iconOptions: IconOptions): IconPlaneOptions[] {
     background: asString(iconOptions.background),
     transparent: iconOptions.transparent,
     rotate: iconOptions.rotate,
+    source: iconOptions.source,
   }));
 }
 
@@ -200,6 +202,11 @@ async function createPlane(
   sourceset: SourceImage[],
   options: IconPlaneOptions
 ): Promise<sharp.Sharp> {
+
+  if(options.source) {
+    sourceset =  await sourceImages(typeof options.source === 'function' ? options.source(options) : options.source);
+  }
+
   const offset =
     Math.round(
       (Math.max(options.width, options.height) * options.offset) / 100
@@ -239,6 +246,9 @@ async function createSvg(
   sourceset: SourceImage[],
   options: IconPlaneOptions
 ): Promise<Buffer> {
+  if(options.source) {
+    sourceset =  await sourceImages(typeof options.source === 'function' ? options.source(options) : options.source);
+  }
   const { width, height } = options;
   const source = bestSource(sourceset, width, height);
   if (source.metadata.format === "svg") {

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -18,7 +18,11 @@ export interface IconPlaneOptions {
   readonly background?: string;
   readonly transparent: boolean;
   readonly rotate: boolean;
-  readonly source?: string | Buffer | (string | Buffer)[] | ((options:IconPlaneOptions) => string | Buffer | (string | Buffer)[])
+  readonly source?:
+    | string
+    | Buffer
+    | (string | Buffer)[]
+    | ((options: IconPlaneOptions) => string | Buffer | (string | Buffer)[]);
 }
 
 function arrayComparator(a: unknown, b: unknown): number {
@@ -202,9 +206,12 @@ async function createPlane(
   sourceset: SourceImage[],
   options: IconPlaneOptions
 ): Promise<sharp.Sharp> {
-
-  if(options.source) {
-    sourceset =  await sourceImages(typeof options.source === 'function' ? options.source(options) : options.source);
+  if (options.source) {
+    sourceset = await sourceImages(
+      typeof options.source === "function"
+        ? options.source(options)
+        : options.source
+    );
   }
 
   const offset =
@@ -246,8 +253,12 @@ async function createSvg(
   sourceset: SourceImage[],
   options: IconPlaneOptions
 ): Promise<Buffer> {
-  if(options.source) {
-    sourceset =  await sourceImages(typeof options.source === 'function' ? options.source(options) : options.source);
+  if (options.source) {
+    sourceset = await sourceImages(
+      typeof options.source === "function"
+        ? options.source(options)
+        : options.source
+    );
   }
   const { width, height } = options;
   const source = bestSource(sourceset, width, height);


### PR DESCRIPTION
```javascript
  const options = {
    icons: {
      favicons: false,
      android: {
          source: ({width, height}) => {
                     return width < 800 ? "/path/to/foo" : "/path/to/bar";
           }
      },
      appleStartup: {
          offset: 2,
          source: "/path/to/asset"
      },
      windows: false,
      yandex: false,
      appleIcon: true,
    },
  };

```